### PR TITLE
Fixed etime parsing issue

### DIFF
--- a/pigra/parser.py
+++ b/pigra/parser.py
@@ -168,9 +168,9 @@ class IgraParser:
         if (value:=line[3:8]) in ("-8888", "-9999"):
             elapsed = None, QualityFlag(value)
         else:
-            dt = datetime.strptime(value.strip(), "%M%S")
-            elapsed = timedelta(minutes=dt.minute,
-                                seconds=dt.second), QualityFlag.PASSED
+            dt = value.replace(' ', '0')
+            elapsed = timedelta(minutes=int(dt[0:3]),
+                                seconds=int(dt[3:])), QualityFlag.PASSED
         # pressure
         if (value:=line[9:15]) == "-9999":
             value = None


### PR DESCRIPTION
- datetime.strptime %M%S does not work for etime.
- The etime format is MMMSS, with M being minutes and S being seconds, and without any zero left-padding.
- %M%S only works for a maximum of 59 minutes and 59 seconds.
- Single digits were being skipped, as were any values greater than 5959.
- Two digits were being parsed as MS, where they should be SS.
- Three digits were being parsed as MMS, unless MM > 59, then it would parse as MSS.
- Parsing is actually faster now, since datetime is not being used.